### PR TITLE
Baseline configuration file

### DIFF
--- a/config/baseline.json
+++ b/config/baseline.json
@@ -1,0 +1,123 @@
+{
+    "command": "train",
+    "gpu_ids": [0, 1, 2, 3],
+    "log_directory": "20210512_ms_challenge_baseline",
+    "model_name": "ms_brain",
+    "debugging": true,
+    "object_detection_params": {
+        "object_detection_path": null
+    },
+    "loader_parameters": {
+        "bids_path": "duke/projects/ivadomed/ms_challenge_2021_BIDS",
+        "target_suffix": [
+            "_seg-lesion"
+        ],
+        "roi_params": {
+            "suffix": null,
+            "slice_filter_roi": null
+        },
+        "contrast_params": {
+            "training_validation": [
+                "t1-FLAIR", "t2-FLAIR"
+            ],
+            "testing": [
+                "t1-FLAIR", "t2-FLAIR"
+            ],
+            "balance": {},
+            "contrast_lst": [
+                "t1-FLAIR", "t2-FLAIR"
+            ]
+        },
+        "slice_filter_params": {
+            "filter_empty_mask": false,
+            "filter_empty_input": true
+        },
+        "slice_axis": "axial",
+        "multichannel": true,
+        "soft_gt": false
+    },
+    "split_dataset": {
+        "fname_split": null,
+        "random_seed": 1313,
+        "center_test": [],
+	"balance": null,
+        "method": "per_patient",
+        "train_fraction": 0.6,
+        "test_fraction": 0.2
+    },
+    "training_parameters": {
+        "batch_size": 24,
+        "loss": {
+            "name": "DiceLoss"
+        },
+        "training_time": {
+            "num_epochs": 200,
+            "early_stopping_patience": 50,
+            "early_stopping_epsilon": 0.001
+        },
+        "scheduler": {
+            "initial_lr": 5e-05,
+            "lr_scheduler": {
+                "name": "CosineAnnealingLR",
+                "base_lr": 1e-05,
+                "max_lr": 0.01
+            }
+        },
+        "balance_samples": {"applied": false, "type": "gt"},
+        "mixup_alpha": null,
+        "transfer_learning": {
+            "retrain_model": null,
+            "retrain_fraction": 1.0
+        }
+    },
+    "default_model": {
+        "name": "Unet",
+        "dropout_rate": 0.3,
+        "bn_momentum": 0.9,
+        "depth": 4,
+        "folder_name": "ms_brain",
+        "in_channel": 5,
+        "out_channel": 1
+    },
+    "postprocessing": {"binarize_prediction": {"thr": 0.5}},
+    "transformation": {
+        "Resample":
+        {
+            "wspace": 1,
+            "hspace": 1,
+            "dspace": 1,
+	    "preprocessing": true
+        },
+        "CenterCrop": {
+            "size": [
+                160,
+                224
+            ],
+            "preprocessing": true
+        },
+        "RandomAffine": {
+            "degrees": 20,
+            "scale": [
+                0.1,
+                0.1
+            ],
+            "translate": [
+                0.1,
+                0.1
+            ],
+            "applied_to": [
+                "im",
+                "gt"
+            ],
+            "dataset_type": [
+                "training"
+            ]
+        },
+        "NumpyToTensor": {},
+        "NormalizeInstance": {
+            "applied_to": [
+                "im"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Things to note about this configuration file:
- This is a vanilla U-Net 2D conventional pipeline using only the ground truth. All images are resampled to 1mmx1mmx1mm and center cropped with dimensions of 160x224 pixels (these parameters were used for the other challenge I'm guessing it will work as well here).
- To run the file simply write a terminal where ivadomed is already installed: `ivadomed -c path/to/baseline.json`
- The parameters `log_directory` and `loader_parameters/bids_path` will need to be updated according to where we want to store the data, how the BIDS folder is named and where you run the command. 
- The parameters `loader_parameters/contrasts_params/{training_validation/testing/contrast_lst}` and `loader_parameters/target_suffix` will have to be updated depending on the contrast name and suffix used to identify the GT.
- Final point: we might have problems with BIDS compatibility. We have 2 time points that we wish to pass as input (multichannel). The multichannel is usually triggered with the number of modalities, but I am pretty sure that "t1-FLAIR" and "t2-FLAIR" are not BIDS compliant, so the loader might not like this. If the "t1" and "t2" is not included in the contrast name, the code will not load the images as multichannel (each input will only be one time point). I contacted Marie-Hélène to know how to approach this. I'll keep you posted. 