### PR TITLE
QC script to assess ANIMA brain masking performance

### DIFF
--- a/preprocessing/qc_brainmask.py
+++ b/preprocessing/qc_brainmask.py
@@ -87,7 +87,7 @@ for patientName in os.listdir(src_folder):
 
         # Check whether some new lesion-voxels are affected by brain extraction
         for expert_id in range(1, 5):
-            gt_fname = os.path.join(src_patient_folder, "ground_truth_expert{}.nii.gz".format(expert_id))
+            gt_fname = os.path.join(dest_patient_folder, "ground_truth_expert{}.nii.gz".format(expert_id))
             gt_im = nib.load(gt_fname)
             is_gt_cropped = np.any(diff_np * gt_im.get_fdata())
             if is_gt_cropped:


### PR DESCRIPTION
## Context:
- We are considering to use the [ANIMA preprocessing pipeline](https://github.com/Inria-Empenn/Anima-Scripts-Public/blob/master/ms_lesion_segmentation/animaMSLongitudinalPreprocessing.py).
- Brain extraction is a critical step, which needs to be properly assessed.

## Feature:
This script simply takes the original image and the binary mask generated by the ANIMA pipeline --> does the difference between the two so that a quick visual inspection can assess whether important anatomical area has been cropped.

## Notes:
- Not tested yet, please do not review yet :-)
- Assume the original data organisation (ie not BIDS yet) since BIDS dataset not available yet --> the script will need to be refactored when.. OR we could BIDSify the preprocessed dataset? TBD in meeting