### PR TITLE
Preprocessing script for improving inter-session registration

### DIFF
--- a/preprocessing/preprocess_data.sh
+++ b/preprocessing/preprocess_data.sh
@@ -84,7 +84,7 @@ sct_maths -i brain_cord_mask.nii.gz -bin 0.5 -o brain_cord_mask.nii.gz
 
 # Finer registration with ANTs
 # TODO: use initial transform iwth -r flag
-antsRegistration -d 3 -m CC[${file_ses2}.nii.gz, ${file_ses1_onlyfile}_reg.nii.gz, 1, 4, Regular, 1] -t SyN[0.5] -c 20x10x2 -s 0x0x1 -f 8x4x2 -n BSpline -x mask_brain_cord.nii.gz -o [warp_, ${file_ses1_onlyfile}_reg-brain.nii.gz] -v 1
+antsRegistration -d 3 -m CC[${file_ses2}.nii.gz, ${file_ses1_onlyfile}_reg.nii.gz, 1, 4, Regular, 1] -t SyN[0.5] -c 20x10x2 -s 0x0x1 -f 8x4x2 -n BSpline -x brain_cord_mask.nii.gz -o [warp_, ${file_ses1_onlyfile}_reg-brain.nii.gz] -v 1
 
 # Go back to parent folder
 cd ..


### PR DESCRIPTION
This PR introduces a SHELL script for preprocessing of the data. This preprocessing will be run for the training and testing data. This processing script does the following:
- Segmentation of the spinal cord on ses-01 and ses-02
- Registration of ses-01 to ses-02 using cord segmentation masks
- Finer registration using brain + SC mask

TODO in subsequent PRs:
- Create a script for quick QC, eg: subtraction of ses-01 and ses-02 and display of sagittal image --> #18 
- Validate registration across all subjects --> #19
- Consider resampling to fixed resolution --> #20

This script relies on pipeline framework `sct_run_batch`. Fixes #10

Fixes #3