### PR TITLE
Resampling and Brain + SC Masking in Preprocessing

### DIFF
--- a/preprocessing/preprocess_data.sh
+++ b/preprocessing/preprocess_data.sh
@@ -119,7 +119,7 @@ fslmaths ${file_ses2_onlyfile}_res.nii.gz -mas brain_cord_mask.nii.gz ${file_ses
 # (2) Go to subject folder for segmentation GTs
 cd $PATH_DATA_PROCESSED/derivatives/labels/$SUBJECT
 
-file_gt1_onlyfile="${SUBJECT}_ses-01_FLAIR_lesion-manual-rater1"
+file_gt1_onlyfile="${SUBJECT}_ses-02_FLAIR_lesion-manual-rater1"
 file_gt1="ses-02/anat/${SUBJECT}_ses-02_FLAIR_lesion-manual-rater1"
 file_gt2_onlyfile="${SUBJECT}_ses-02_FLAIR_lesion-manual-rater2"
 file_gt2="ses-02/anat/${SUBJECT}_ses-02_FLAIR_lesion-manual-rater2"


### PR DESCRIPTION
This PR:
* Implements `flirt` based resampling for the two FLAIR sessions as well as the segmentation GTs. The resampling is isotropic with `1mm x 1mm x 1mm` voxel dimensions. 
* Implements brain + SC masking with `fslmaths -mas` using the `brain_cord_mask.nii.gz` in the preprocessing pipeline.
* Copies the `derivatives` to `PATH_OUTPUT` from `PATH_DATA` as well, and implements the necessary path modifications.

With this PR, we aim to have a ready-to-go preprocessing pipeline which we can use for training and evaluation. After running this new pipeline,
* The following files will be the final images for session 1 and 2: 
   * ses01 (*registered*) -> `${file_ses1_onlyfile}_reg-brain_masked.nii.gz`
   * ses02 -> `${file_ses2_onlyfile}_res_masked.nii.gz`
* The following files are the final GTs for all experts and consensus:
   * rater1 -> `${file_gt1_onlyfile}_res_masked.nii.gz`
   * rater2 -> `${file_gt2_onlyfile}_res_masked.nii.gz`
   * rater3 -> `${file_gt3_onlyfile}_res_masked.nii.gz`
   * rater4 -> `${file_gt4_onlyfile}_res_masked.nii.gz`
   * consensus -> `${file_gtc_onlyfile}_res_masked.nii.gz`
   
**Next Steps:**
* Validate the design choices made in `preprocess_data.sh`. For example, the `ses-01` and `ses-02` folders for both input images and `derivatives` are copied without any modifications to `PATH_OUTPUT` and the newly generated files are saved in the parent subject directory. ✅
* Update ses01 and ses02 filepaths in `qc_preprocess.py`. ✅
* Write a mini-script to convert the `PATH_DATA` to be BIDS-compatible / `ivadomed`-compatible. This script should ideally be called after `qc_preprocess.py` (i.e. after making sure everything works as expected) and should remove the intermediate files. Since we might want to keep the intermediate files somewhere, this mini-script should work in a new directory and leave `PATH_DATA` as is.
* Add a `README.md` under `preprocessing` which shows how to run the scripts and download the dependencies. ✅