### PR TITLE
Device Assignments Compatible with Data-Parallel Processes

### DIFF
--- a/modeling/models.py
+++ b/modeling/models.py
@@ -364,7 +364,7 @@ class ModifiedUNet3D(nn.Module):
 
         if self.cfg.task == '2':
             # Concat. TPs
-            x = torch.cat([x1, x2], dim=1).to(self.cfg.device)
+            x = torch.cat([x1, x2], dim=1).to(x1.device)
             # x: (B, 2, SV, SV, SV)
         else:
             # Discard x2
@@ -581,9 +581,9 @@ class Transformer(nn.Module):
 
     def forward(self, x):
         # Get position IDs and timepoint IDs
-        position_ids = torch.cat([torch.arange(self.cfg.num_patches)] * 2).unsqueeze(0).to(self.cfg.device)
+        position_ids = torch.cat([torch.arange(self.cfg.num_patches)] * 2).unsqueeze(0).to(x.device)
         # position_ids: (1, 2 * S)
-        timepoint_ids = torch.tensor([0] * self.cfg.num_patches + [1] * self.cfg.num_patches).unsqueeze(0).to(self.cfg.device)
+        timepoint_ids = torch.tensor([0] * self.cfg.num_patches + [1] * self.cfg.num_patches).unsqueeze(0).to(x.device)
         # timepoint_ids: (1, 2 * S)
 
         x, context_out, context_features = self.embeddings(x, position_ids, timepoint_ids)
@@ -632,7 +632,7 @@ class TransUNet3D(nn.Module):
         # x2: (B, S, 1, P, P, P)
 
         # Concat. TPs
-        x = torch.cat([x1, x2], dim=1).to(self.cfg.device)
+        x = torch.cat([x1, x2], dim=1).to(x1.device)
         # x: (B, 2 * S, 1, P, P, P)
 
         x, attention_weights, context_out, context_features = self.transformer(x)


### PR DESCRIPTION
This PR changes device assignments for the implemented (i) Modified3DUNet and (ii) TransUNet3D architectures and essentially allows compatibility with data-parallel processes.

Before the device assignments implemented in this branch, we were occasionally getting the following errors when we tried to run data-parallel training with `main.py` and `-loc=-1` argument coupled with multiple GPU access:
* `RuntimeError: Caught RuntimeError in replica 1 on device 1.`
* `RuntimeError: Expected tensor for argument #1 'input' to have the same device as tensor for argument #2 'weight'; but device 0 does not equal 1 (while checking arguments for cudnn_convolution)`

Instead of the `device` parameter passed to the `ModelConfig` at the beginning of the `main.py` script, we now instead assign `x.device` to whatever parameters necessary during training & inference where `x` is any tensor passed from the training & validation loops in the `main.py` script to the model(s) implemented in `models.py`.

What this means in practical terms is that, using
```
export CUDA_VISIBLE_DEVICES=<[GPU_IDs]>
python main.py -loc -1 ...
```
where `<[GPU_IDs]>` are the IDs of `k` GPUs each with a memory of `N` GB (where `k` >= 2 and `N` ~= 16 GB for `rosenberg` and ~= 64 GB for `romane`), we can effectively work on a GPU with memory `kN` GB.