### PR TITLE
Implementation of Monte Carlo dropout as an ensemble method

### DIFF
--- a/modeling/datasets.py
+++ b/modeling/datasets.py
@@ -331,7 +331,7 @@ class MSSeg2Dataset(Dataset):
     def __len__(self):
         return len(self.subvolumes)
 
-    def test(self, model, device, is_mcd, num_mc_samples):
+    def test(self, model, device, num_mc_samples):
         """Implements the test phase via animaSegPerfAnalyzer"""
         assert model is not None
 
@@ -412,7 +412,7 @@ class MSSeg2Dataset(Dataset):
                     x1 = torch.tensor(ses01_subvolume, dtype=torch.float).view(1, 1, *ses01_subvolume.shape).to(device)
                     x2 = torch.tensor(ses02_subvolume, dtype=torch.float).view(1, 1, *ses02_subvolume.shape).to(device)
 
-                if is_mcd:   # Do Monte Carlo Averaging
+                if num_mc_samples > 0:   # Do Monte Carlo Averaging
                     seg_y_hats = []
                     # Forward pass through the network num_mc_samples times and combine them by averaging.
                     for i_mc in range(num_mc_samples):

--- a/modeling/main.py
+++ b/modeling/main.py
@@ -74,7 +74,7 @@ parser.add_argument('--eps', type=float, default=1e-8,
 
 parser.add_argument('-mcd', '--mc_dropout', default=False, action='store_true',
                     help='To use Monte Carlo samples for validation and testing')
-parser.add_argument('-n_mc', '--num_mc_samples', default=5, type=int, help="Number of MC samples to use")
+parser.add_argument('-n_mc', '--num_mc_samples', default=0, type=int, help="Number of MC samples to use")
 
 parser.add_argument('-s', '--save', default='./saved_models', type=str,
                     help='Path to the saved models directory')
@@ -538,7 +538,7 @@ def main_worker(rank, world_size):
             dataset.train = False
             if args.mc_dropout:
                 enable_dropout(model)   # enabling only dropout for the test phase
-            dataset.test(model=model, device=device, is_mcd=args.mc_dropout, num_mc_samples=args.num_mc_samples)
+            dataset.test(model=model, device=device, num_mc_samples=args.num_mc_samples)
             exit(0)
 
     # Cleanup DDP if applicable


### PR DESCRIPTION
This PR introduces some minor modifications to the Modified3DUNet model by adding the possibility of performing a Monte Carlo (MC) averaging of the predicted segmentation during the validation and test phases. 
Important things to note:
- The training phase remains unchanged (as does the model architecture) because dropout is already used by default.
- In case the argument for MC dropout is `True`, the validation loop is repeated until the defined number of MC samples is reached.
- For testing, each input from the list of subvolumes is stochastically forward-passed through the network `num_mc_samples` times.
- The `.eval()` method automatically disables dropout, so the dropout layers were explicitly enabled for both validation and testing.

This implementation can also be considered as an indirect (cheap) version of the ensemble method.