### PR TITLE
Added code for creating '_clean' version of preprocessed data

### DIFF
--- a/preprocessing/preprocess_data.sh
+++ b/preprocessing/preprocess_data.sh
@@ -90,6 +90,7 @@ sct_deepseg_sc -i ${file_ses2_onlyfile}_res.nii.gz -c t1 -o ${file_ses2_onlyfile
 
 # Perform registration ses-01 --> ses-02
 # NOTE: We are passing the un-resampled / original ses-01 as the input to avoid double interpolation
+# NOTE: We do NOT need to co-register the brain, because it was ALREADY co-registered by the MS-CHALLENGE team.
 sct_register_multimodal -i ${file_ses1}.nii.gz -iseg ${file_ses1_onlyfile}_seg.nii.gz -d ${file_ses2_onlyfile}_res.nii.gz -dseg ${file_ses2_onlyfile}_seg.nii.gz -o ${file_ses1_onlyfile}_reg.nii.gz -param step=1,type=seg,algo=slicereg,metric=MeanSquares,smooth=3
 
 # Dilate spinal cord mask
@@ -215,6 +216,51 @@ for file in "${FILES_TO_CHECK[@]}"; do
     echo "${SUBJECT}/${file} does not exist" >> $PATH_LOG/_error_check_output_files.log
   fi
 done
+
+# Go back to the root output path
+cd $PATH_OUTPUT
+
+# Create and populate clean data processed folder for training
+PATH_DATA_PROCESSED_CLEAN="${PATH_DATA_PROCESSED}_clean"
+
+
+# Copy over required BIDs files
+mkdir -p $PATH_DATA_PROCESSED_CLEAN $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/ses-01/ $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/ses-01/anat
+mkdir -p $PATH_DATA_PROCESSED_CLEAN $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/ses-02/ $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/ses-02/anat
+
+rsync -avzh $PATH_DATA_PROCESSED/dataset_description.json $PATH_DATA_PROCESSED_CLEAN/
+rsync -avzh $PATH_DATA_PROCESSED/participants.* $PATH_DATA_PROCESSED_CLEAN/
+rsync -avzh $PATH_DATA_PROCESSED/README $PATH_DATA_PROCESSED_CLEAN/
+rsync -avzh $PATH_DATA_PROCESSED/dataset_description.json $PATH_DATA_PROCESSED_CLEAN/derivatives/
+
+# Refer to lines 142-144 to know which preprocessed files to copy 
+# MR images for ses-01
+rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_ses1_onlyfile}_reg-brain_masked.nii.gz $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/ses-01/anat/${file_ses1_onlyfile}.nii.gz
+rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/ses-01/anat/${file_ses1_onlyfile}.json $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/ses-01/anat/${file_ses1_onlyfile}.json
+# MR images for ses-02
+rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/${file_ses2_onlyfile}_res_masked.nii.gz $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/ses-02/anat/${file_ses2_onlyfile}.nii.gz
+rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/ses-02/anat/${file_ses2_onlyfile}.json $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/ses-02/anat/${file_ses2_onlyfile}.json
+
+# Refer to lines 181-186 to know which preprocessed GTs to copy 
+# Note that the original data has the GTs from the 2nd timepoint ie ses-02
+mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives $PATH_DATA_PROCESSED_CLEAN/derivatives/labels $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02 $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat
+
+# Preprocessed GT from rater 1
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/${file_gt1_onlyfile}_res_masked.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt1_onlyfile}.nii.gz
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt1_onlyfile}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt1_onlyfile}.json
+# Preprocessed GT from rater 2
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/${file_gt2_onlyfile}_res_masked.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt2_onlyfile}.nii.gz
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt2_onlyfile}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt2_onlyfile}.json
+# Preprocessed GT from rater 3
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/${file_gt3_onlyfile}_res_masked.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt3_onlyfile}.nii.gz
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt3_onlyfile}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt3_onlyfile}.json
+# Preprocessed GT from rater 4
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/${file_gt4_onlyfile}_res_masked.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt4_onlyfile}.nii.gz
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt4_onlyfile}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gt4_onlyfile}.json
+# Preprocessed consensus GT 
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/${file_gtc_onlyfile}_res_masked.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gtc_onlyfile}.nii.gz
+rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gtc_onlyfile}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/ses-02/anat/${file_gtc_onlyfile}.json
+
 
 # Display useful info for the log
 end=`date +%s`


### PR DESCRIPTION
As the title suggests, this PR aims to "complete" the preprocessing script by creating a `_clean` version of the preprocessed data by copying only the final cropped/registered files (and the intermediate ones generated during preprocessing), something that has been done in the preprocessing scripts for `mp2rage` and `model_seg_sci` projects. 

Most of the added code has been modified from scripts in those repositories, see for e.g. `model_seg_sci` project's [preprocessing](https://github.com/ivadomed/model_seg_sci/blob/main/preprocessing/preprocess_data.sh#L150).

The updated code should output a `data_preprocessed_clean` folder which has the following structure:

<details>
<summary> Output folder structure </summary>
<img width="600" alt="Screen Shot 2022-06-14 at 2 49 12 PM" src="https://user-images.githubusercontent.com/53445351/173666682-3b5a8932-a26c-4c9e-9d30-4dfbbcc04810.png">

</details>

With this the preprocessing pipeline can be run again, and the `data_processed_clean` folder could be used as it is for training.